### PR TITLE
fix: default csp when report_to var is null

### DIFF
--- a/cloudfront-response-headers-policy/main.tf
+++ b/cloudfront-response-headers-policy/main.tf
@@ -22,7 +22,7 @@ resource "aws_cloudfront_response_headers_policy" "main" {
     dynamic "content_security_policy" {
       for_each = var.content_security_policy != null && contains(var.mimes, "text/html") ? [1] : []
       content {
-        content_security_policy =  try("${var.content_security_policy.value};report-to ${var.content_security_policy.report_to};report-uri ${var.report_to.default}",null)
+        content_security_policy = try("${var.content_security_policy.value};report-to ${var.content_security_policy.report_to};report-uri ${var.report_to.default}", var.content_security_policy.value)
         override = try(var.content_security_policy.override, false)
       }
     }


### PR DESCRIPTION
The dynamic `content_security_policy` block is added without checking if `report_to` var is null.

When `report_to` is null, we don't need to append `report-to` or `report-uri` directives to csp.